### PR TITLE
Remove bypass from the list of applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Recaptcha.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :httpoison, :eex, :bypass]]
+    [applications: [:logger, :httpoison, :eex]]
   end
 
   defp description do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
 ExUnit.start()
+Application.ensure_all_started(:bypass)


### PR DESCRIPTION
Remove `:bypass` from the list of applications in `mix.exs`. Having it in the list of applications causes issues in other project's test suites where an error would be raised, because the bypass application could not be found:

```bash
~/Developer/tiger ⬢ master [$!?] :: 30s
▶ mix test.setup
==> recaptcha
Generated recaptcha app
==> tiger
** (Mix) Could not start application bypass: could not find application file: bypass.app
```

The test helper module is also updated to make sure that the bypass application is started when running the test suite by calling `Application.ensure_all_started(:bypass)`.